### PR TITLE
Allow to use symbolic links for xdg-terminals desktop files

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -168,7 +168,7 @@ find_entry_path(){
 		if [ -d "${DATA_DIR}/${DATA_PREFIX_DIR}" ]
 		then
 			debug "looking in \"${DATA_DIR}/${DATA_PREFIX_DIR}\""
-			FILE_LIST="$(find "${DATA_DIR}/${DATA_PREFIX_DIR}" -type f -iname "*.desktop" -printf "%P\n")"
+			FILE_LIST="$(find -L "${DATA_DIR}/${DATA_PREFIX_DIR}" -type f -iname "*.desktop" -printf "%P\n")"
 			ID_LIST="$(printf "%s" "$FILE_LIST" | tr '/' '-')"
 			ID_NUM="$(printf "%s" "$ID_LIST" | grep -n "^${ENTRY_ID}$" | head -n 1 | cut -d : -f 1)"
 			ENTRY_FILE="$(printf "%s" "$FILE_LIST" | head -n "${ID_NUM:-0}" | tail -n 1)"


### PR DESCRIPTION
Since many terminals desktop files can be used unaltered, it makes sense
to allow the use of symbolic links, so users can simply link to their
installation desktop files in $XDG_DATA_HOME.
