### PR TITLE
Improve tests some more

### DIFF
--- a/test/bin/xterm
+++ b/test/bin/xterm
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo xterm "$@"

--- a/test/data/quoting/xdg-terminals/quoting-term.desktop
+++ b/test/data/quoting/xdg-terminals/quoting-term.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=Default Terminal
+Type=Application
+Exec=printf '%s\n' quoting\ terminal "with 'complex' arguments" 'and \"back\\slashes\"'

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -7,6 +7,7 @@ setup() {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/nothing"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/nothing"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/nothing"
+	export PATH="$BATS_TEST_DIRNAME/bin:$PATH"
 }
 
 assert_success() {
@@ -25,6 +26,12 @@ assert_output() {
 		diff -u <(echo "$expected") <(echo "$output") >&2
 		return 1
 	}
+}
+
+@test "uses xterm -e as the fallback" {
+	run "$XTE" argument
+	assert_success
+	assert_output "xterm -e argument"
 }
 
 @test "uses globally configured entry" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -2,6 +2,7 @@
 
 setup() {
 	: "${XTE:=$BATS_TEST_DIRNAME/../xdg-terminal-exec}"
+	unset XDG_CURRENT_DESKTOP
 	export XDG_CONFIG_HOME="$BATS_TEST_DIRNAME/nothing"
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/nothing"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/nothing"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -34,6 +34,22 @@ assert_output() {
 	assert_output "default terminal"
 }
 
+@test "ignores missing config directory" {
+	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/missing:$BATS_TEST_DIRNAME/config/default"
+	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
+	run "$XTE"
+	assert_success
+	assert_output "default terminal"
+}
+
+@test "ignores missing data directory" {
+	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
+	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/missing:$BATS_TEST_DIRNAME/data/default"
+	run "$XTE"
+	assert_success
+	assert_output "default terminal"
+}
+
 @test "uses locally configured entry" {
 	export XDG_CONFIG_HOME="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/default"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -163,11 +163,11 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/quoting"
 	xte and 'custom arguments'
 	assert_output <<-'EOF'
-quoting terminal
-with 'complex' arguments
-and \"back\\slashes\"
--e
-and
-custom arguments
+		quoting terminal
+		with 'complex' arguments
+		and \"back\\slashes\"
+		-e
+		and
+		custom arguments
 	EOF
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-bats_require_minimum_version 1.5.0
 
 setup() {
 	: "${XTE:=$BATS_TEST_DIRNAME/../xdg-terminal-exec}"
@@ -10,7 +9,16 @@ setup() {
 }
 
 xte() {
-	run -0 $XTE "$@"
+	run $XTE "$@"
+	assert_success
+}
+
+assert_success() {
+	[ "$status" -eq 0 ] || {
+		echo "status: $status" >&2
+		echo "output: $output" >&2
+		return 1
+	}
 }
 
 assert_output() {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -21,7 +21,7 @@ assert_output() {
 	expected="${*:-$(cat)}"
 	[ "$output" = "$expected" ] || {
 		echo "status: $status" >&2
-		echo -n "output: " >&2
+		echo "output diff:" >&2
 		diff -u <(echo "$expected") <(echo "$output") >&2
 		return 1
 	}

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -8,11 +8,6 @@ setup() {
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/nothing"
 }
 
-xte() {
-	run $XTE "$@"
-	assert_success
-}
-
 assert_success() {
 	[ "$status" -eq 0 ] || {
 		echo "status: $status" >&2
@@ -34,51 +29,59 @@ assert_output() {
 @test "uses globally configured entry" {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
 @test "uses locally configured entry" {
 	export XDG_CONFIG_HOME="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
 @test "finds any global entry when there is no configuration" {
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
 @test "uses configured exec arg" {
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/execarg"
-	xte argument
+	run "$XTE" argument
+	assert_success
 	assert_output "execarg terminal -- argument"
 }
 
 @test "adds default exec arg" {
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte argument
+	run "$XTE" argument
+	assert_success
 	assert_output "default terminal -e argument"
 }
 
 @test "deals with large desktop entries" {
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/huge"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "huge terminal"
 }
 
 @test "finds any local entry when there is no configuration" {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
 @test "prefers earlier configured entry" {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/preferred:$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/preferred:$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "preferred terminal"
 }
 
@@ -87,7 +90,8 @@ assert_output() {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/preferred"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "preferred terminal"
 }
 
@@ -96,7 +100,8 @@ assert_output() {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/hidden"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
@@ -105,7 +110,8 @@ assert_output() {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/tryexec-fails"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "default terminal"
 }
 
@@ -115,7 +121,8 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/desktop/lists"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
 	export XDG_CURRENT_DESKTOP=desktop
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "specific terminal"
 }
 
@@ -125,7 +132,8 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/desktop/lists"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
 	export XDG_CURRENT_DESKTOP=other
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "generic terminal"
 }
 
@@ -135,7 +143,8 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/desktop/show"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
 	export XDG_CURRENT_DESKTOP=only
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "only terminal"
 }
 
@@ -145,7 +154,8 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/desktop/show"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
 	export XDG_CURRENT_DESKTOP=other
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "not terminal"
 }
 
@@ -155,13 +165,15 @@ assert_output() {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/desktop/show"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"
 	export XDG_CURRENT_DESKTOP=not
-	xte
+	run "$XTE"
+	assert_success
 	assert_output "generic terminal"
 }
 
 @test "quotes commands and arguments correctly" {
 	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/quoting"
-	xte and 'custom arguments'
+	run "$XTE" and 'custom arguments'
+	assert_success
 	assert_output <<-'EOF'
 		quoting terminal
 		with 'complex' arguments

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -14,7 +14,7 @@ xte() {
 }
 
 assert_output() {
-	[ "$output" = "$*" ]
+	[ "$output" = "${*:-$(cat)}" ]
 }
 
 @test "uses globally configured entry" {
@@ -143,4 +143,17 @@ assert_output() {
 	export XDG_CURRENT_DESKTOP=not
 	xte
 	assert_output "generic terminal"
+}
+
+@test "quotes commands and arguments correctly" {
+	export XDG_DATA_HOME="$BATS_TEST_DIRNAME/data/quoting"
+	xte and 'custom arguments'
+	assert_output <<-'EOF'
+quoting terminal
+with 'complex' arguments
+and \"back\\slashes\"
+-e
+and
+custom arguments
+	EOF
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -14,7 +14,13 @@ xte() {
 }
 
 assert_output() {
-	[ "$output" = "${*:-$(cat)}" ]
+	expected="${*:-$(cat)}"
+	[ "$output" = "$expected" ] || {
+		echo "status: $status" >&2
+		echo -n "output: " >&2
+		diff -u <(echo "$expected") <(echo "$output") >&2
+		return 1
+	}
 }
 
 @test "uses globally configured entry" {


### PR DESCRIPTION
these changes:
* improve output when a test fails
* unset XDG_CURRENT_DESKTOP in most tests so we don't accidentally assume it's defined
* add tests for missing directories
* add a test for the xterm fallback
* add a test for quoting arguments, both in the Exec line and to xdg-terminal-exec

the quoting test currently fails and i can remove it if you prefer