### PR TITLE
Fix scripts errors

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -128,6 +128,7 @@ find_any_entry(){
 			ENTRY_FILES="$(find "${DATA_DIR}/${DATA_PREFIX_DIR}" -type f -iname "*.desktop" -printf "%P\n")"
 			while read ENTRY_FILE
 			do
+				[ -z "$ENTRY_FILE" ] && continue
 				ENTRY_ID="$(printf "%s" "$ENTRY_FILE" | tr '/' '-')"
 				ENTRY_PATH="${DATA_DIR}/${DATA_PREFIX_DIR}/$ENTRY_FILE"
 				check_entry_id "$ENTRY_ID" || continue

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -299,6 +299,11 @@ fi
 debug "EXEC=$EXEC"
 debug "EXECARG=$EXECARG"
 
+if ! command -v "$EXEC" &>/dev/null; then
+	>&2 printf "no terminal found\n"
+	exit 1
+fi
+
 #[ "$DEBUG" = "1" ] && exit 0
 if [ "$#" = "0" ]
 then


### PR DESCRIPTION
As I was trying out the script, I noticed a couple situations in which the script could fail:
1. not having any terminals configured and not having xterm installed would result in `exec: xterm: not found`
2. an empty data directory would cause all sorts of script errors
3. ~~a terminal name with an asterisk could get shell expanded (unlikely, but good practice to handle it anyway)~~