### PR TITLE
Add support for /usr/etc configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Default paths are resolved into:
   - `$HOME/.config/xdg-terminals.list`
   - `/etc/xdg/$desktop-xdg-terminals.list`
   - `/etc/xdg/xdg-terminals.list`
+  - `/usr/etc/xdg/$desktop-xdg-terminals.list`
+  - `/usr/etc/xdg/xdg-terminals.list`
 - data
   - `$HOME/.local/share/xdg-terminals/`
   - `/usr/local/share/xdg-terminals`

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -22,7 +22,7 @@ DATA_PREFIX_DIR=xdg-terminals
 CONFIG_NAME=xdg-terminals.list
 
 DATA_HIERARCHY="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-CONF_HIERARCHY="${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+CONF_HIERARCHY="${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg:/usr/etc/xdg}"
 
 DATA=''
 BLACKLIST=''


### PR DESCRIPTION
An increasing number of distributions are using locations in /usr (such as /usr/etc) for packaging their distribution configuration.

This is to enable /etc to be the location for "system wide" configuration without complicating a distributions ability to ship sensible defaults

A large number of upstreams used by openSUSE have already adopted support for this, including pam, netcfg, openssh, etc https://en.opensuse.org/openSUSE:Packaging_UsrEtc for more info

I'm keen to use xdg-terminal-exec on some projects I have around openSUSE MicroOS, so I'd like this to work here also :)

Kind Regards,
Richard