### PR TITLE
Adding flag to follow symlinks

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -124,7 +124,7 @@ find_any_entry(){
 		if [ -d "${DATA_DIR}/${DATA_PREFIX_DIR}" ]
 		then
 			debug "searching in \"${DATA_DIR}/${DATA_PREFIX_DIR}\""
-			ENTRY_FILES="$(find "${DATA_DIR}/${DATA_PREFIX_DIR}" -type f -iname "*.desktop" -printf "%P\n")"
+			ENTRY_FILES="$(find -L "${DATA_DIR}/${DATA_PREFIX_DIR}" -type f -iname "*.desktop" -printf "%P\n")"
 			while read ENTRY_FILE
 			do
 				[ -z "$ENTRY_FILE" ] && continue


### PR DESCRIPTION
On NixOS it is very likely that a xdg-terminals folder is actually a symlink.
That way the *.desktop files places inside could not be found.
My little change fixes that.

Every other find operation in the script also follows symlinks so I assume there is no issue with just merging.