### PR TITLE
xdg-terminal-exec: set errexit and nounset

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Proposal for XDG terminal execution utility and default terminal specification.
 
 The configuration spec is crafted in image of [mime-apps-spec](https://specifications.freedesktop.org/mime-apps-spec/latest/ar01s02.html) using different names in similar structure, governed by [basedir-spec](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Terminal emulators with their exec arguments are be described by desktop entries placed in directories named `xdg-terminals` provided via XDG_DATA hierarchy.
+Terminal emulators with their exec arguments are described by desktop entries placed in directories named `xdg-terminals` provided via XDG_DATA hierarchy.
 
-Preferred terminal is configured in config files named `xdg-terminals.list` provided via XDG_CONFIG hierarchy.
-Format for config file is a a simple newline-separated list of desktop entries. #Comments, dangling whitespaces are trimmed.
+Preferred terminals are configured in config files named `xdg-terminals.list` provided via XDG_CONFIG hierarchy.
+Format for config file is a a simple newline-separated list of desktop entries. #Comments and dangling whitespaces are trimmed.
 
 Default paths are resolved into:
 
@@ -22,7 +22,8 @@ Default paths are resolved into:
   - `/usr/local/share/xdg-terminals`
   - `/usr/share/xdg-terminals`
 
-where `$desktop` is lowercase list of colon-separated names of current DE.
+Where `$desktop` is a lowercased string derived from `$XDG_CURRENT_DESKTOP`.
+If `$XDG_CURRENT_DESKTOP` is set then it contains a colon-separated list of names for the current DE.
 
 ## Priority of selecting entry:
   - Read configs throughout XDG_CONFIG hierarchy.
@@ -32,7 +33,9 @@ where `$desktop` is lowercase list of colon-separated names of current DE.
   - If all of the above fails, `xterm` and `-e` are used.
 
 ## Desktop entry for terminal
-For defining terminals usual desktop entries may be used. The only addition is the key `X-ExecArg` which defines the exection argument for the terminal emulator. It defaults to `-e` if unset, but may be specifically set to an empty string. With this behavior stock entries for terminals that use `-e` as execution argument may be used unaltered.
+When defining terminals usual desktop entries may be used. The only addition is the key `X-ExecArg` which defines the execution argument for the terminal emulator.
+It defaults to `-e` if unset, but may be specifically set to an empty string.
+With this behavior stock entries for terminals that use `-e` as execution argument may be used unaltered.
 
 ## syntax
 ```

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -17,6 +17,10 @@
 # ENTRY_ID - ENTRY_FILE with '/' swapped for '-' (see section E of Desktop Entry Spec)
 # ENTRY_PATH - full path of specific desktop entry file
 
+# Treat non-zero exit status from simple commands as an error
+# Treat unset variables as errors when performing parameter expansion
+set -eu
+
 DATA_PREFIX_DIR=xdg-terminals
 CONFIG_NAME=xdg-terminals.list
 
@@ -30,12 +34,7 @@ EXECARG=''
 
 OIFS="$IFS"
 
-# default debug (and drop non-numeric value)
-if [ -z "$DEBUG" ] || [ "$DEBUG" != "${DEBUG:##*[!0-9]*}" ]; then
-	DEBUG=0
-fi
-
-if [ "$DEBUG" -gt 0 ]; then
+if [ "${DEBUG-0}" = '1' ]; then
 	debug() { printf '%s\n' "$1" >&2; }
 else
 	debug() { :; }
@@ -56,7 +55,7 @@ trim_comment() {
 
 generate_config_list() {
 	# Generate list of possible config files for current DE
-	DESKTOPS_LC="$(printf '%s' "$XDG_CURRENT_DESKTOP" | tr '[:upper:]' '[:lower:]')"
+	DESKTOPS_LC="$(printf '%s' "${XDG_CURRENT_DESKTOP-}" | tr '[:upper:]' '[:lower:]')"
 	IFS=':'
 	debug "lower case desktops are: '${DESKTOPS_LC}'"
 	for CONFIG_DIR in $CONF_HIERARCHY; do
@@ -270,6 +269,7 @@ read_entry_path() {
 		fi
 		[ "$DE" = '1' ] && printf '%s\n' "$LINE"
 	done < "${ENTRY_PATH}"
+	return 0
 }
 
 ENTRY_PATH="$(find_preferred_entry)"


### PR DESCRIPTION
An alternative fix for #24, sorry about that.
Also contains a commit with small changes to the README