### PR TITLE
xdg-terminal-exec: Move more code into functions

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -139,9 +139,29 @@ find_entry_path() {
 # Modifies following global variables:
 # EXEC : Program to execute, possibly with arguments. See spec for details.
 # EXECARG : Execution argument for the terminal emulator.
+# TERMINAL : Set if application has been categorised as a terminal emulator
 check_entry() {
 	# Order of checks is important
 	case $1 in
+	'Categories'*=*)
+		# Enforce only if reading from 'applications' subdirectory
+		! check_bool "${XTE_STOCK_TERMINALS-false}" && return 0
+		categories=$(trim_start "${1#*=}")
+		debug "read Categories '$categories'"
+		IFS=';'
+		for category in $categories; do
+			if [ "$category" = 'TerminalEmulator' ]; then
+				debug "entry categorised as a Terminal Emulator"
+				# Set global variable
+				TERMINAL=true
+				IFS="$OIFS"
+				return 0
+			fi
+		done
+		IFS="$OIFS"
+		# Default in this case is to fail
+		return 1
+		;;
 	'OnlyShowIn'*=*)
 		onlyShowIn=$(trim_start "${1#*=}")
 		debug "read OnlyShowIn '$onlyShowIn'"
@@ -225,6 +245,7 @@ read_entry_path() {
 			# Reset values that might have been set
 			unset EXEC
 			unset EXECARG
+			unset TERMINAL
 			return 1
 			;;
 		# Start of the next group header, stop
@@ -264,24 +285,21 @@ ENTRY_IDS=$(
 
 debug "final entry ID list '$ENTRY_IDS'"
 
-# select DATA_PREFIX_DIR and entry filtering:
-# operate in separate "xdg-terminals" subdirs (default),
-# or filter terminals from native "applications" subdirs by category
+# Select which subdirectory to search for terminal emulators in:
+# 'xdg-terminals', a sepparate directory that exists for this script specifically (default),
+# 'applications', the standardised location for application desktop entry files
+# When searching in 'applications', entries will be filtered based on their Category key
 if check_bool "${XTE_STOCK_TERMINALS-false}"; then
-	debug "filtering stock terminal entries from applications"
 	DATA_PREFIX_DIR=applications
-	list_entry_files() {
-		find -L "$1" -type f -name '[[:alnum:]-_.]*.desktop' |
-			xargs -r grep -lE '^[[:space:]]*Categories[[:space:]]*=[[:space:]]*(.*;)?TerminalEmulator(;|$)' |
-			sort
-	}
 else
-	debug "getting terminal entries from xdg-terminals"
 	DATA_PREFIX_DIR=xdg-terminals
-	list_entry_files() {
-		find -L "$1" -type f -name '[[:alnum:]-_.]*.desktop' | sort
-	}
 fi
+
+list_entry_files() {
+	find -L "$1" -type f -name '[[:alnum:]-_.]*.desktop' | sort
+}
+
+debug "searching for terminal entries in '$DATA_PREFIX_DIR'"
 
 # Generate list of possible terminal entry files and also add their IDs to
 IFS=':'
@@ -315,12 +333,15 @@ for data_dir in $DATA_HIERARCHY; do
 		EOF
 	fi
 done
+IFS="$OIFS"
 
 # Loop through IDs, any empty lines should be discarded by word splitting
 IFS="$N"
 for entry_id in $ENTRY_IDS; do
 	# See read_entry_path and check_entry
 	if read_entry_path "$(find_entry_path "$entry_id")"; then
+		# If reading from 'applications' subdirectory, ensure entry is a Terminal Emulator
+		check_bool "${XTE_STOCK_TERMINALS-false}" && [ -z "${TERMINAL-}" ] && continue
 		# Default to '-e' if unset
 		EXECARG=${EXECARG-'-e'}
 		break

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -25,11 +25,6 @@ OIFS="$IFS"
 N='
 '
 
-trim_start() {
-	# Remove all but leading whitespace, and trim that from the given string
-	printf '%s' "${1#"${1%%[![:space:]]*}"}"
-}
-
 check_bool() {
 	case "$1" in
 	true | True | TRUE | yes | Yes | YES | 1) return 0 ;;
@@ -173,21 +168,23 @@ match_entry_path() {
 	return 1
 }
 
-# Check validity of a given entry line
+# Check validity of a given entry key - value pair
 # Modifies following global variables:
 # EXEC : Program to execute, possibly with arguments. See spec for details.
 # EXECARG : Execution argument for the terminal emulator.
 # TERMINAL : Set if application has been categorised as a terminal emulator
-check_entry() {
+check_entry_key() {
+	key="$1"
+	value="$2"
+
 	# Order of checks is important
-	case $1 in
+	case $key in
 	'Categories'*=*)
 		# Enforce only if reading from 'applications' subdirectory
 		! check_bool "${XTE_STOCK_TERMINALS-false}" && return 0
-		categories=$(trim_start "${1#*=}")
-		debug "read Categories '$categories'"
+		debug "read Categories '$value'"
 		IFS=';'
-		for category in $categories; do
+		for category in $value; do
 			if [ "$category" = 'TerminalEmulator' ]; then
 				debug "entry categorised as a Terminal Emulator"
 				# Set global variable
@@ -201,15 +198,14 @@ check_entry() {
 		return 1
 		;;
 	'OnlyShowIn'*=*)
-		onlyShowIn=$(trim_start "${1#*=}")
-		debug "read OnlyShowIn '$onlyShowIn'"
+		debug "read OnlyShowIn '$value'"
 		IFS=';'
-		for name in $onlyShowIn; do
+		for target in $value; do
 			IFS=':'
 			for desktop in ${XDG_CURRENT_DESKTOP-}; do
 				IFS="$OIFS"
-				debug "checking OnlyShowIn match '$desktop'='$name'"
-				[ "$desktop" = "$name" ] && return 0
+				debug "checking OnlyShowIn match '$desktop'='$target'"
+				[ "$desktop" = "$target" ] && return 0
 			done
 		done
 		IFS="$OIFS"
@@ -217,49 +213,40 @@ check_entry() {
 		return 1
 		;;
 	'NotShowIn'*=*)
-		notShowIn=$(trim_start "${1#*=}")
-		debug "read NotShowIn '$notShowIn'"
+		debug "read NotShowIn '$value'"
 		IFS=';'
-		for name in $notShowIn; do
+		for target in $value; do
 			IFS=':'
 			for desktop in ${XDG_CURRENT_DESKTOP-}; do
 				IFS="$OIFS"
-				debug "checking NotShowIn match '$desktop'='$name'"
-				[ "$desktop" = "$name" ] && return 1
+				debug "checking NotShowIn match '$desktop'='$target'"
+				[ "$desktop" = "$target" ] && return 1
 			done
 		done
 		IFS="$OIFS"
 		# Default in this case is to succeed
 		return 0
 		;;
-	'X-ExecArg'*=*)
+	'X-ExecArg'*=* | 'ExecArg'*=*)
 		# Set global variable
-		EXECARG=$(trim_start "${1#*=}")
-		debug "read execution argument '$EXECARG'"
-		;;
-	'ExecArg'*=*)
-		# Set global variable
-		EXECARG=$(trim_start "${1#*=}")
+		EXECARG=$value
 		debug "read execution argument '$EXECARG'"
 		;;
 	'TryExec'*=*)
-		executable=$(trim_start "${1#*=}")
-		debug "checking TryExec executable '$executable'"
-		command -v "$executable" > /dev/null || return 1
+		debug "checking TryExec executable '$value'"
+		command -v "$value" > /dev/null || return 1
 		;;
 	'Hidden'*=*)
-		hidden=$(trim_start "${1#*=}")
-		debug "checking Hidden boolean '$hidden'"
-		[ "$hidden" = 'true' ] && return 1
+		debug "checking Hidden boolean '$value'"
+		[ "$value" = 'true' ] && return 1
 		;;
 	'Exec'*=*)
 		# Set global variable
-		EXEC=$(trim_start "${1#*=}")
+		EXEC=$value
 		# Get first word from read Exec value
 		eval "set -- $EXEC"
-		exec0="$1"
-		debug "checking Exec[0] executable '$exec0'"
-		command -v "$exec0" > /dev/null || return 1
+		debug "checking Exec[0] executable '$1'"
+		command -v "$1" > /dev/null || return 1
 		;;
 	esac
 	# By default unrecognised keys, empty lines and comments get ignored
@@ -274,9 +261,14 @@ read_entry_path() {
 		case $line in
 		# `There should be nothing preceding [the Desktop Entry group] in the desktop entry file but [comments]`
 		'[Desktop Entry]'*) ;;
-		# A `Key=Value` pair, check it
+		# A `Key=Value` pair
 		[A-Za-z0-9-]*)
-			check_entry "$line" && continue
+			# Split value from pair
+			value=${line#*=}
+			# Remove all but leading spaces, and trim that from the value
+			value=${value#"${value%%[! ]*}"}
+			# Check the key
+			check_entry_key "$line" "$value" && continue
 			# Reset values that might have been set
 			unset EXEC
 			unset EXECARG

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -18,8 +18,7 @@
 # Disable pathname expansion
 set -euf
 
-# Backup original IFS value
-# It is assumed that $OIFS contains the default IFS value
+# Store original IFS value, assumed to contain the default: <space><tab><newline>
 OIFS="$IFS"
 # Newline, utility variable used throughout the script
 N='
@@ -62,6 +61,8 @@ find_config_paths() {
 		printf '%s\n' "$directory"/"$config_file"
 	done
 }
+# Mask IFS withing function to allow temporary changes
+alias find_config_paths='IFS= find_config_paths'
 
 # Parse all config files and populate $ENTRY_IDS with read desktop entry IDs
 read_config_paths() {
@@ -88,6 +89,8 @@ read_config_paths() {
 		done < "$config_path"
 	done
 }
+# Mask IFS withing function to allow temporary changes
+alias read_config_paths='IFS= read_config_paths'
 
 # Check if newline delimited list $1 contains string $2
 contains() {
@@ -97,6 +100,8 @@ contains() {
 	done
 	return 1
 }
+# Mask IFS withing function to allow temporary changes
+alias contains='IFS= contains'
 
 # Find all desktop entry files from standardised paths, populate $ENTRY_PATHS and add fallback IDs
 find_entry_paths() {
@@ -140,6 +145,8 @@ find_entry_paths() {
 		done
 	done
 }
+# Mask IFS withing function to allow temporary changes
+alias find_entry_paths='IFS= find_entry_paths'
 
 # Find a matching file path for a given entry ID
 match_entry_path() {
@@ -163,10 +170,11 @@ match_entry_path() {
 		printf '%s' "$entry_path"
 		return 0
 	done
-	IFS="$OIFS"
 	debug 'no matching entry path found'
 	return 1
 }
+# Mask IFS withing function to allow temporary changes
+alias match_entry_path='IFS= match_entry_path'
 
 # Check validity of a given entry key - value pair
 # Modifies following global variables:
@@ -189,11 +197,9 @@ check_entry_key() {
 				debug "entry categorised as a Terminal Emulator"
 				# Set global variable
 				TERMINAL=true
-				IFS="$OIFS"
 				return 0
 			fi
 		done
-		IFS="$OIFS"
 		# Default in this case is to fail
 		return 1
 		;;
@@ -203,12 +209,10 @@ check_entry_key() {
 		for target in $value; do
 			IFS=':'
 			for desktop in ${XDG_CURRENT_DESKTOP-}; do
-				IFS="$OIFS"
 				debug "checking OnlyShowIn match '$desktop'='$target'"
 				[ "$desktop" = "$target" ] && return 0
 			done
 		done
-		IFS="$OIFS"
 		# Default in this case is to fail
 		return 1
 		;;
@@ -218,12 +222,10 @@ check_entry_key() {
 		for target in $value; do
 			IFS=':'
 			for desktop in ${XDG_CURRENT_DESKTOP-}; do
-				IFS="$OIFS"
 				debug "checking NotShowIn match '$desktop'='$target'"
 				[ "$desktop" = "$target" ] && return 1
 			done
 		done
-		IFS="$OIFS"
 		# Default in this case is to succeed
 		return 0
 		;;
@@ -244,6 +246,7 @@ check_entry_key() {
 		# Set global variable
 		EXEC=$value
 		# Get first word from read Exec value
+		IFS="$OIFS"
 		eval "set -- $EXEC"
 		debug "checking Exec[0] executable '$1'"
 		command -v "$1" > /dev/null || return 1
@@ -251,13 +254,15 @@ check_entry_key() {
 	esac
 	# By default unrecognised keys, empty lines and comments get ignored
 }
+# Mask IFS withing function to allow temporary changes
+alias check_entry='IFS= check_entry'
 
 # Read entry from given path, only parse 'Desktop Entry' group
 read_entry_path() {
 	entry_path="$1"
 	debug "reading desktop entry '$entry_path'"
 	# Let `read` trim leading/trailing whitespace from the line
-	while read -r line; do
+	while IFS="$OIFS" read -r line; do
 		case $line in
 		# `There should be nothing preceding [the Desktop Entry group] in the desktop entry file but [comments]`
 		'[Desktop Entry]'*) ;;
@@ -300,6 +305,8 @@ find_entry() {
 	# No valid entry was found
 	return 1
 }
+# Mask IFS withing function to allow temporary changes
+alias find_entry='IFS= find_entry'
 
 # All desktop entry ids in descending order of preference
 ENTRY_IDS=''

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -92,11 +92,16 @@ read_config_paths() {
 	IFS="$N"
 	for config_path in $(find_config_paths); do
 		debug "reading config '$config_path'"
+		# Nonexistant file is not an error
 		[ -f "$config_path" ] || continue
 		# Let `read` trim leading/trailing whitespace from the line
 		while IFS="$OIFS" read -r line; do
 			debug "read line '$line'"
 			case $line in
+			# Whether to search for entries in 'xdg-terminals' or 'applications'
+			# Can be overriden by $XTE_STOCK_TERMINALS
+			use_stock_applications) XTE_STOCK_TERMINALS=${XTE_STOCK_TERMINALS-true} ;;
+			use_xdg_terminals) XTE_STOCK_TERMINALS=${XTE_STOCK_TERMINALS-false} ;;
 			# `[The extensionless entry filename] should be a valid D-Bus well-known name.`
 			[A-Za-z_]*) ENTRY_IDS=${ENTRY_IDS:+${ENTRY_IDS}${N}}$line ;;
 			esac
@@ -243,43 +248,12 @@ ENTRY_IDS=''
 # Modifies $ENTRY_IDS
 read_config_paths
 
-# whether to use entries in 'xdg-terminals' or stock terminals in 'applications'
-# decide by checking for special lines in configs
-# default is governed by XTE_STOCK_TERMINALS
-STOCK_TERMINALS=$(
-	# find special parameters in ENTRY_IDS
-	while read -r LINE; do
-		case "$LINE" in
-		# special parameters to control data subdir and entry filtering
-		use_stock_applications)
-			debug "encountered use_stock_applications"
-			echo true
-			break
-			;;
-		use_xdg_terminals)
-			debug "encountered use_xdg_terminals"
-			echo false
-			break
-			;;
-		esac
-	done <<- EOL
-		$ENTRY_IDS
-	EOL
-)
-
-if [ -z "$STOCK_TERMINALS" ]; then
-	debug "no stock terminals control in configs, XTE_STOCK_TERMINALS: ${XTE_STOCK_TERMINALS:-undefined}"
-	STOCK_TERMINALS=${XTE_STOCK_TERMINALS:-false}
-fi
-
-debug "STOCK_TERMINALS=$STOCK_TERMINALS"
-
-# drop special and empty lines from ENTRY_IDS, deduplicate
+# drop empty lines from ENTRY_IDS, deduplicate
 ENTRY_IDS=$(
 	LIST=''
 	while read -r LINE; do
 		case "$LINE" in
-		use_stock_applications | use_xdg_terminals | '') continue ;;
+		'') continue ;;
 		*) LIST=$(append "$LIST" "$LINE") ;;
 		esac
 	done <<- EOL
@@ -293,7 +267,7 @@ debug "final entry ID list '$ENTRY_IDS'"
 # select DATA_PREFIX_DIR and entry filtering:
 # operate in separate "xdg-terminals" subdirs (default),
 # or filter terminals from native "applications" subdirs by category
-if check_bool "$STOCK_TERMINALS"; then
+if check_bool "${XTE_STOCK_TERMINALS-false}"; then
 	debug "filtering stock terminal entries from applications"
 	DATA_PREFIX_DIR=applications
 	list_entry_files() {

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -41,22 +41,6 @@ check_bool() {
 	esac
 }
 
-append() {
-	# returns $N-separated list $1 with $2 item appended if not already there
-	IFS="$N"
-	FOUND=0
-	while read -r ITEM; do
-		[ -n "$ITEM" ] && printf '%s\n' "$ITEM"
-		[ "$ITEM" = "$2" ] && FOUND=1
-	done <<- EOL
-		$1
-	EOL
-	if [ "$FOUND" = "0" ]; then
-		printf '%s\n' "$2"
-	fi
-	IFS="$OIFS"
-}
-
 if check_bool "${DEBUG-0}"; then
 	debug() { printf '%s\n' "$1" >&2; }
 else
@@ -107,6 +91,58 @@ read_config_paths() {
 			esac
 			# By default empty lines and comments get ignored
 		done < "$config_path"
+	done
+}
+
+# Check if newline delimited list $1 contains string $2
+contains() {
+	IFS="$N"
+	for item in $1; do
+		[ "$item" = "$2" ] && return 0
+	done
+	return 1
+}
+
+# Find all desktop entry files from standardised paths, populate $ENTRY_PATHS and add fallback IDs
+find_entry_paths() {
+	# Directory hierarchy that is searched for desktop entry files
+	data_directories="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
+	# Select which subdirectory to search for terminal emulators in:
+	# 'xdg-terminals', a sepparate directory that exists for this script specifically (default),
+	# 'applications', the standardised location for application desktop entry files
+	# When searching in 'applications', entries will be filtered based on their Category key
+	if check_bool "${XTE_STOCK_TERMINALS-false}"; then
+		data_subdirectory='applications'
+	else
+		data_subdirectory='xdg-terminals'
+	fi
+	debug "searching for terminal entries in '$data_subdirectory'"
+	# Loop through paths
+	IFS=':'
+	for directory in $data_directories; do
+		# Normalise base path and append the data subdirectory with a trailing '/'
+		directory=${directory%/}/$data_subdirectory/
+		debug "searching '$directory'"
+		# Nonexistent directory is not an error
+		[ -d "$directory" ] || continue
+		# Loop through paths
+		IFS="$N"
+		# Print order of found files is unpredictable, sort them
+		for entry_path in $(find -L "$directory" -type f -name '[[:alnum:]-_.]*.desktop' | sort); do
+			debug "found desktop entry '$entry_path'"
+			# Create entry ID from path
+			entry_path=${entry_path#"$directory"}
+			entry_id=$(printf '%s' "$entry_path" | tr '/' '-')
+			# Do not add duplicate IDs
+			if ! contains "$ENTRY_IDS" "$entry_id"; then
+				debug "adding fallback ID '$entry_id'"
+				ENTRY_IDS=${ENTRY_IDS:+${ENTRY_IDS}${N}}$entry_id
+			fi
+			# Delimit end of the data directory path by adding an extra '/' character
+			# This is done so the ID can be recreated later
+			entry_path="$directory"/"$entry_path"
+			ENTRY_PATHS=${ENTRY_PATHS:+${ENTRY_PATHS}${N}}$entry_path
+		done
 	done
 }
 
@@ -259,81 +295,17 @@ read_entry_path() {
 	esac
 }
 
-# Directory hierarchy searched for desktop entry files
-DATA_HIERARCHY="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
-
-# All desktop entry paths in descending order of preference
-ENTRY_PATHS=''
 # All desktop entry ids in descending order of preference
 ENTRY_IDS=''
 # Modifies $ENTRY_IDS
 read_config_paths
-
-# drop empty lines from ENTRY_IDS, deduplicate
-ENTRY_IDS=$(
-	LIST=''
-	while read -r LINE; do
-		case "$LINE" in
-		'') continue ;;
-		*) LIST=$(append "$LIST" "$LINE") ;;
-		esac
-	done <<- EOL
-		$ENTRY_IDS
-	EOL
-	printf '%s' "$LIST"
-)
+# All desktop entry paths in descending order of preference
+ENTRY_PATHS=''
+# Modifies $ENTRY_PATHS and $ENTRY_IDS
+find_entry_paths
 
 debug "final entry ID list '$ENTRY_IDS'"
-
-# Select which subdirectory to search for terminal emulators in:
-# 'xdg-terminals', a sepparate directory that exists for this script specifically (default),
-# 'applications', the standardised location for application desktop entry files
-# When searching in 'applications', entries will be filtered based on their Category key
-if check_bool "${XTE_STOCK_TERMINALS-false}"; then
-	DATA_PREFIX_DIR=applications
-else
-	DATA_PREFIX_DIR=xdg-terminals
-fi
-
-list_entry_files() {
-	find -L "$1" -type f -name '[[:alnum:]-_.]*.desktop' | sort
-}
-
-debug "searching for terminal entries in '$DATA_PREFIX_DIR'"
-
-# Generate list of possible terminal entry files and also add their IDs to
-IFS=':'
-for data_dir in $DATA_HIERARCHY; do
-	# Remove trailing '/' from base path
-	data_dir=${data_dir%/}
-	IFS="$OIFS"
-	if [ -d "$data_dir"/"$DATA_PREFIX_DIR" ]; then
-		debug "searching in '$data_dir/$DATA_PREFIX_DIR'"
-		while read -r entry_path; do
-			[ -z "$entry_path" ] && continue
-			debug "found desktop entry '$entry_path'"
-			# Remove data directory path
-			entry_path="${entry_path#"$data_dir"/"$DATA_PREFIX_DIR"/}"
-			# Create entry ID from path
-			entry_id="$(printf '%s' "$entry_path" | tr '/' '-')"
-			debug "adding matching id '$entry_id'"
-			# Append found ID to list, using brace expansion for better readability
-			ENTRY_IDS="${ENTRY_IDS}${N}${entry_id}"
-			# Prepend data directory path, and delimit its end using an extra '/' character
-			# This is done so the ID can be recreated in `find_entry_path`
-			# Other possible way of storing the data direcotry could be:
-			# $data_dir/$DATA_PREFIX_DIR/$entry_path/$entry_id
-			# Where '.desktop/' is the delimiter, as IDs do not contain '/', and entry files must end in '.desktop'
-			entry_path="$data_dir"/"$DATA_PREFIX_DIR"//"$entry_path"
-			# Append found path to list, using brace expansion for better readability
-			ENTRY_PATHS="${ENTRY_PATHS}${N}${entry_path}"
-			# Print order of found files is unpredictable, sort them
-		done <<- EOF
-			$(list_entry_files "$data_dir"/"$DATA_PREFIX_DIR")
-		EOF
-	fi
-done
-IFS="$OIFS"
+debug "final entry path list '$ENTRY_PATHS'"
 
 # Loop through IDs, any empty lines should be discarded by word splitting
 IFS="$N"

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -147,9 +147,9 @@ find_entry_paths() {
 }
 
 # Find a matching file path for a given entry ID
-find_entry_path() {
+match_entry_path() {
 	entry_id="$1"
-	debug "finding path for entry id '$entry_id'"
+	debug "matching path for entry id '$entry_id'"
 
 	# Loop through paths, any empty lines should be discarded by word splitting
 	IFS="$N"
@@ -161,6 +161,8 @@ find_entry_path() {
 		entry_path="${entry_path%//*}"/"$found_entry_id"
 		found_entry_id="$(printf '%s' "$found_entry_id" | tr '/' '-')"
 		debug "checking entry id '$found_entry_id'"
+		# `If [entries with duplicate IDs] exist, it is undefined which is selected.`
+		# For simplicity, the first ID encountered is the one used
 		[ "$found_entry_id" != "$entry_id" ] && continue
 		debug "found entry path '$entry_path'"
 		printf '%s' "$entry_path"
@@ -267,8 +269,6 @@ check_entry() {
 read_entry_path() {
 	entry_path="$1"
 	debug "reading desktop entry '$entry_path'"
-	# failsafe for empty entries
-	HAS_DATA=false
 	# Let `read` trim leading/trailing whitespace from the line
 	while read -r line; do
 		case $line in
@@ -276,7 +276,6 @@ read_entry_path() {
 		'[Desktop Entry]'*) ;;
 		# A `Key=Value` pair, check it
 		[A-Za-z0-9-]*)
-			HAS_DATA=true
 			check_entry "$line" && continue
 			# Reset values that might have been set
 			unset EXEC
@@ -289,10 +288,25 @@ read_entry_path() {
 		esac
 		# By default empty lines and comments get ignored
 	done < "$entry_path"
-	case $HAS_DATA in
-	true) return 0 ;;
-	false) return 1 ;;
-	esac
+}
+
+# Loop through IDs and try to find a valid entry
+find_entry() {
+	IFS="$N"
+	for entry_id in $ENTRY_IDS; do
+		# Find matching entry
+		entry_path=$(match_entry_path "$entry_id")
+		# Validate entry
+		read_entry_path "$entry_path" || continue
+		# Check that the entry is actually executable
+		[ -z "${EXEC-}" ] && continue
+		# If reading from 'applications' subdirectory, ensure entry is a Terminal Emulator
+		[ "${XTE_STOCK_TERMINALS-}" = 'true' ] && [ -z "${TERMINAL-}" ] && continue
+		# Entry is valid, stop
+		return 0
+	done
+	# No valid entry was found
+	return 1
 }
 
 # All desktop entry ids in descending order of preference
@@ -307,25 +321,11 @@ find_entry_paths
 debug "final entry ID list '$ENTRY_IDS'"
 debug "final entry path list '$ENTRY_PATHS'"
 
-# Loop through IDs, any empty lines should be discarded by word splitting
-IFS="$N"
-for entry_id in $ENTRY_IDS; do
-	# See read_entry_path and check_entry
-	if read_entry_path "$(find_entry_path "$entry_id")"; then
-		# If reading from 'applications' subdirectory, ensure entry is a Terminal Emulator
-		check_bool "${XTE_STOCK_TERMINALS-false}" && [ -z "${TERMINAL-}" ] && continue
-		# Default to '-e' if unset
-		EXECARG=${EXECARG-'-e'}
-		break
-	fi
-done
-IFS="$OIFS"
+find_entry || true
 
-if [ -z "${EXEC-}" ]; then
-	# Set defaults
-	EXEC='xterm'
-	EXECARG='-e'
-fi
+# Set defaults
+: "${EXEC="xterm"}"
+: "${EXECARG="-e"}"
 
 # Store original argument list, before it's modified
 ORIG_ARGV="$*"

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -84,21 +84,25 @@ find_config_paths() {
 	done
 }
 
-# Read config from given path, print sanitised entries
-read_config_path() {
-	config_path="$1"
-
-	debug "reading config '$config_path'"
-	[ -f "$config_path" ] || return 0
-	# Let `read` trim leading/trailing whitespace from the line
-	while read -r line; do
-		debug "read line '$line'"
-		case $line in
-		# `[The extensionless entry filename] should be a valid D-Bus well-known name.`
-		[A-Za-z_]*) printf '%s\n' "$line" ;;
-		esac
-		# By default empty lines and comments get ignored
-	done < "$config_path"
+# Parse all config files and populate $ENTRY_IDS with read desktop entry IDs
+read_config_paths() {
+	# All config files are read immediatelly, rather than on demand, even if it's more IO intensive
+	# This way all IDs are already known, and in order of preference, before iterating over them
+	# This allows for easier deduplication, when adding fallback IDs later on
+	IFS="$N"
+	for config_path in $(find_config_paths); do
+		debug "reading config '$config_path'"
+		[ -f "$config_path" ] || continue
+		# Let `read` trim leading/trailing whitespace from the line
+		while IFS="$OIFS" read -r line; do
+			debug "read line '$line'"
+			case $line in
+			# `[The extensionless entry filename] should be a valid D-Bus well-known name.`
+			[A-Za-z_]*) ENTRY_IDS=${ENTRY_IDS:+${ENTRY_IDS}${N}}$line ;;
+			esac
+			# By default empty lines and comments get ignored
+		done < "$config_path"
+	done
 }
 
 # Find a matching file path for a given entry ID
@@ -236,15 +240,8 @@ DATA_HIERARCHY="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local
 ENTRY_PATHS=''
 # All desktop entry ids in descending order of preference
 ENTRY_IDS=''
-
-# All config files are read immediatelly, rather than on demand, even if it's more IO intensive
-# This way all IDs are already known, and in order of preference, before iterating over them
-# This allows for easier deduplication, when adding fallback IDs later on
-IFS="$N"
-for config_path in $(find_config_paths); do
-	# Append read ID(s) to list, using brace expansion for better readability
-	ENTRY_IDS=${ENTRY_IDS}${N}$(read_config_path "$config_path")
-done
+# Modifies $ENTRY_IDS
+read_config_paths
 
 # whether to use entries in 'xdg-terminals' or stock terminals in 'applications'
 # decide by checking for special lines in configs

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -63,6 +63,27 @@ else
 	debug() { :; }
 fi
 
+# Find and print all config file paths
+find_config_paths() {
+	# Directories searched for config files, in decending order of preference
+	config_directories="${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+	# Config filename to parse
+	config_file=xdg-terminals.list
+	# Generate list of possible config files for current Dekstop Environment
+	# TODO: Should this be case insensitive? Desktop entry checks that also use $XDG_CURRENT_DESKTOP are not
+	lowercase_desktops="$(printf '%s' "${XDG_CURRENT_DESKTOP-}" | tr '[:upper:]' '[:lower:]')"
+	debug "lowercase desktops are: '$lowercase_desktops'"
+	# Loop through paths
+	# TODO: Replace this by a find call?
+	IFS=':'
+	for directory in $config_directories; do
+		for desktop in $lowercase_desktops; do
+			printf '%s\n' "$directory"/"$desktop"-"$config_file"
+		done
+		printf '%s\n' "$directory"/"$config_file"
+	done
+}
+
 # Read config from given path, print sanitised entries
 read_config_path() {
 	config_path="$1"
@@ -208,38 +229,21 @@ read_entry_path() {
 	esac
 }
 
-# Name of config files to search and read
-CONFIG_NAME=xdg-terminals.list
-
-# Directory hierarchy searched for terminal config and desktop entry files
+# Directory hierarchy searched for desktop entry files
 DATA_HIERARCHY="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
-CONF_HIERARCHY="${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
 
 # All desktop entry paths in descending order of preference
 ENTRY_PATHS=''
 # All desktop entry ids in descending order of preference
 ENTRY_IDS=''
 
-# Generate list of possible config files for current DE
-# TODO: Should this be case insensitive? Desktop entry checks that also use $XDG_CURRENT_DESKTOP are not
-lowercase_desktops="$(printf '%s' "${XDG_CURRENT_DESKTOP-}" | tr '[:upper:]' '[:lower:]')"
-debug "lowercase desktops are: '$lowercase_desktops'"
-# All config files are searched for, and read immediatelly, rather than when out of IDs
-# This way all possible IDs are know before iterating over them, and are in order of preference
-# Further down, duplicate IDs are then removed using `awk`
-# This avoids having to use cumbersome blacklists, or fragile string operations, to deal with them
-IFS=':'
-for config_dir in $CONF_HIERARCHY; do
-	# Remove trailing '/' from base path
-	config_dir=${config_dir%/}
+# All config files are read immediatelly, rather than on demand, even if it's more IO intensive
+# This way all IDs are already known, and in order of preference, before iterating over them
+# This allows for easier deduplication, when adding fallback IDs later on
+IFS="$N"
+for config_path in $(find_config_paths); do
 	# Append read ID(s) to list, using brace expansion for better readability
-	IFS=':'
-	for desktop in $lowercase_desktops; do
-		IFS="$OIFS"
-		ENTRY_IDS="${ENTRY_IDS}${N}$(read_config_path "$config_dir"/"$desktop"-"$CONFIG_NAME")"
-	done
-	IFS="$OIFS"
-	ENTRY_IDS="${ENTRY_IDS}${N}$(read_config_path "$config_dir"/"$CONFIG_NAME")"
+	ENTRY_IDS=${ENTRY_IDS}${N}$(read_config_path "$config_path")
 done
 
 # whether to use entries in 'xdg-terminals' or stock terminals in 'applications'


### PR DESCRIPTION
See commit messages for details

Now that most functionality is in separate functions, tests could be written for each individually
Should make for a simpler and more comprehensive set of test