### PR TITLE
xdg-terminal-exec: Don't default to `xterm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,14 @@ The default value of `XTE_STOCK_TERMINALS` is currently `false`, but will most l
     - in each tier `$desktop-xdg-terminals.list` gets first priority, `xdg-terminals.list` gets second priority
     - each entry found in configs is checked for applicability (same rules as in Desktop Entry Spec) and is skipped on failure.
   - If no valid entries were found among those marked in configs, every entry found in XDG_DATA hierarchy is checked in a row. First applicable will be used.
-  - If all of the above fails, `xterm` and `-e` are used.
+  - If all of the above fails, error is returned.
 
 ## Desktop entry for terminal
 
-When defining terminals usual desktop entries may be used. The only addition is the key `X-ExecArg` which defines the execution argument for the terminal emulator.
-It defaults to `-e` if unset, but may be specifically set to an empty string.
-With this behavior stock entries for terminals that use `-e` as execution argument may be used unaltered.
+Stock desktop entry for terminal emulator may be used. Command execution argument defaults to `-e`.
+Key `X-ExecArg=` can be used to override it (or omit by explicitly setting empty) if terminal emulator uses a different argument.
 
-## syntax
+## Syntax
 
 ```
 xdg-terminal-exec [command [arguments]]
@@ -60,10 +59,10 @@ If run without any arguments, only the terminal itself (value of `Exec=`) will b
 If command and its arguments are given, then values of both `Exec=` and `X-ExecArg=` will be used.
 Run with `DEBUG=1` to see verbose messages to stderr.
 
-## limitations
+## Limitations
 
 There is no mechanism for handling special quoting and arguments/strings that may be required for some terminals.
-Argument array is transmitted as is.
+Argument array given on command line is transmitted as is.
 
 At least when using xterm, command:
 ```

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -31,12 +31,6 @@ assert_output() {
 	}
 }
 
-@test "uses xterm -e as the fallback" {
-	run "$XTE" argument
-	assert_success
-	assert_output "xterm -e argument"
-}
-
 @test "uses globally configured entry" {
 	export XDG_CONFIG_DIRS="$BATS_TEST_DIRNAME/config/default"
 	export XDG_DATA_DIRS="$BATS_TEST_DIRNAME/data/default"

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -289,7 +289,7 @@ find_entry() {
 		# Entry is valid, stop
 		return 0
 	done
-	echo "No valid terminal entry was found" >&2
+	echo "No valid terminal entry was found in ${data_subdirectory}" >&2
 	return 1
 }
 # Mask IFS withing function to allow temporary changes

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -284,10 +284,12 @@ find_entry() {
 		[ -z "${EXEC-}" ] && continue
 		# If reading from 'applications' subdirectory, ensure entry is a Terminal Emulator
 		[ "${XTE_STOCK_TERMINALS-}" = 'true' ] && [ -z "${TERMINAL-}" ] && continue
+		# Set defaults
+		: "${EXECARG="-e"}"
 		# Entry is valid, stop
 		return 0
 	done
-	# No valid entry was found
+	debug "no valid entry was found"
 	return 1
 }
 # Mask IFS withing function to allow temporary changes
@@ -302,11 +304,7 @@ find_entry_paths
 
 debug "final entry ID list '$ENTRY_IDS'"
 
-find_entry || true
-
-# Set defaults
-: "${EXEC="xterm"}"
-: "${EXECARG="-e"}"
+find_entry || exit 1
 
 # Store original argument list, before it's modified
 ORIG_ARGV="$*"

--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -289,7 +289,7 @@ find_entry() {
 		# Entry is valid, stop
 		return 0
 	done
-	debug "no valid entry was found"
+	echo "No valid terminal entry was found" >&2
 	return 1
 }
 # Mask IFS withing function to allow temporary changes


### PR DESCRIPTION
Based on #30, only last commit differs
In a separate request, as this is a significant change

Address #21
I'm against adding command line flags to to the script, so maybe a `$NO_EXEC` environmental variable could be implemented
If `$NO_EXEC='true'`, the script could print the path to the found entry and then exit