### PR TITLE
xdg-terminal-exec: Fix matching <hyphen-minus>

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -342,7 +342,7 @@ validate_entry_action_id() {
 
 	case "$1" in
 	# invalid characters or degrees of emptiness
-	*[!a-zA-Z0-9-_.]* | *[!a-zA-Z0-9-_.] | [!a-zA-Z0-9-_.]* | [!a-zA-Z0-9-_.] | '' | .desktop)
+	*[!a-zA-Z0-9_.-]* | *[!a-zA-Z0-9_.-] | [!a-zA-Z0-9_.-]* | [!a-zA-Z0-9_.-] | '' | .desktop)
 		echo "Skipping unsupported Entry ID '$1'" >&2
 		check=false
 		;;


### PR DESCRIPTION
It was interpreted as a part of a range in ash
This seemed like a bug, but a closer look at the docs rules it as [undefined behaviour](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03_05)

While talking about `validate_entry_action_id`, do you have examples of entries that need this sort of validation?
Optimally, all invalid entries would be skipped by the `find -name` call
And I don't think the script should validate the given action IDs, `check_entry_key` should catch them and them outright not working feels obvious enough that a user would notice and fix their mistake

I'd quite like to not have to write tests for this function, if at all possible :smile: 