### PR TITLE
xdg-terminal-exec: Prune invalid desktop entries

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -134,7 +134,7 @@ find_entry_paths() {
 		# Loop through paths
 		IFS="$N"
 		# Print order of found files is unpredictable, sort them
-		for entry_path in $(find -L "$directory" -type f -name '[[:alnum:]-_.]*.desktop' | sort); do
+		for entry_path in $(find -L "$directory" -type f -name '*.desktop' ! -path "$directory/*[^[:alnum:]_./-]*" | sort); do
 			entry_paths=${entry_paths:+${entry_paths}${N}}$entry_path
 			# Remove data directory path from ID
 			entry_ids=${entry_ids:+${entry_ids}${N}}${entry_path#"$directory"}


### PR DESCRIPTION
Only allow valid characters in desktop entry ID part of the path
If false positives from exotic `$XDG_DATA_*` directories are acceptable, the line can be made shorter by removing the preceding `$directory/`

This _should_ catch any invalid entry paths, hopefully