### PR TITLE
xdg-terminal-exec: Simplify entry search

### DIFF
--- a/xdg-terminal-exec
+++ b/xdg-terminal-exec
@@ -262,59 +262,38 @@ replace() {
 
 # Find and map all desktop entry files from standardised paths into aliases
 find_entry_paths() {
-	# When searching in 'applications', entries will be filtered based on their Category key
+	debug "registering entries"
 	# Loop through paths
 	IFS=':'
 	for directory in $APPLICATIONS_DIRS; do
 		debug "searching '$directory'"
 		# Nonexistent directory is not an error
 		[ -d "$directory" ] || continue
-		# Loop through paths
+		# Loop through entry paths and IDs
 		IFS="$N"
-		# Find all desktop entries with valid names
-		# Print order of found files is unpredictable, sort them
-		for entry_path in $(find -L "$directory" -type f -name '[a-zA-Z0-9_]*.desktop' '!' -name '*[^a-zA-Z0-9_.-]*' | sort); do
-			entry_paths=${entry_paths:+${entry_paths}${N}}$entry_path
-			# Remove data directory path from ID
-			entry_ids=${entry_ids:+${entry_ids}${N}}${entry_path#"$directory"}
-		done
-	done
-	# Convert all file path fragments into IDs in one operation
-	entry_ids=$(printf '%s' "${entry_ids-}" | tr '/' '-')
-	#entry_ids=$(replace "${entry_ids-}" '/' '-')
-	debug "registering entries"
-	# Loop through paths and IDs simultaneously
-	IFS="$N"
-	while read -r entry_path && read -r entry_id <&3; do
-		if [ -z "$entry_path" ] || [ -z "$entry_id" ]; then
-			debug "empty data: entry_path: '$entry_path', entry_id: '$entry_id'"
-			continue
-		fi
-
-		# since we are moving up the XDG heirarchy, the first encoutered path for entry ID is used
-		if alias "$entry_id" > /dev/null 2>&1; then
-			debug "skipped '$entry_path' as '$entry_id' (overridden earlier)"
-		else
-			# alias can fail on weird (invalid) entry ID
-			# Could add a proper validator above, but might be too taxing doing it on all entries,
-			# so this is just a first line of defence, more sensitive in bash than dash btw.
-			# A proper validator is applied later on entry parsing.
-			# shellcheck disable=SC2139
-			if alias "$entry_id"="entry_path='$entry_path'" > /dev/null 2>&1; then
+		while read -r entry_path && read -r entry_id; do
+			# since we are moving up the XDG heirarchy, the first encoutered path for entry ID is used
+			if alias "$entry_id" > /dev/null 2>&1; then
+				debug "skipped '$entry_path' as '$entry_id' (overridden earlier)"
+			else
+				# shellcheck disable=SC2139
+				alias "$entry_id"="entry_path='$entry_path'" > /dev/null 2>&1
 				debug "registered '$entry_path' as entry '$entry_id'"
 				# Add as a fallback ID regardles if it's a duplicate
 				FALLBACK_ENTRY_IDS=${FALLBACK_ENTRY_IDS:+${FALLBACK_ENTRY_IDS}${N}}$entry_id
 				debug "added fallback ID '$entry_id'"
-			else
-				error "Skipped '$entry_path' due to unsupported filename"
 			fi
-		fi
-		# Use '//' as delimiter, as it can't be found within valid paths nor IDs
-	done <<- // 3<<- //
-		${entry_paths-}
-	//
-		${entry_ids-}
-	//
+		done <<- //
+			$(
+				# Find all desktop entries with valid names
+				find -L "$directory" -type f -name '[a-zA-Z0-9_]*.desktop' ! -path '*[^a-zA-Z0-9_./-]*' |
+					# Print order of found files is unpredictable, sort them
+					sort |
+					# Print entry path and convert it into an ID and print that too
+					awk '{ print; $0=substr($0, '${#directory}' + 1); gsub("/", "-"); print }'
+			)
+		//
+	done
 }
 # Mask IFS withing function to allow temporary changes
 alias find_entry_paths='IFS= find_entry_paths'


### PR DESCRIPTION
Should have similar, if not better, performance
Also removes the unnecessary guard around `alias`, as `find` was made stricter in a previous commit, and prunes any paths that would result in an invalid ID

This seems like the "correct" way of doing something like this, so I hope there's no performance regressions for you either